### PR TITLE
Add build matrix for different `BASE_IMAGE`s

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -15,6 +15,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        base-image:
+          - mambaorg/micromamba:git-8440cec-jammy@sha256:b8bff8398715103ddb31fb26e967db43c6ed15da63a6708121f83a3f657d3101
+          - mambaorg/micromamba:jammy-cuda-11.8.0@sha256:e10f98576e3b01c64a969374835d3b6bc1f481e6ff092cf3c4d032f36513d795
     # Set permissions for GitHub token
     # <https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github>
     permissions:
@@ -56,5 +61,6 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: BASE_IMAGE=${{ matrix.base-image }}
         cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
         cache-to: type=inline


### PR DESCRIPTION
I'd really like to use this `.devcontainer` and currently have a script to build this `Dockerfile` for a different `BASE_IMAGE`. It would be great not to have to maintain this myself but instead prebuild devcontainers for different `BASE_IMAGE`s, which will likely provide value to others too.

I can add more images to the matrix BTW.

@maresb, what do you think?

