### PR TITLE
Fix metadata for CUDA image

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -36,15 +36,21 @@ jobs:
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
 
-      - name: Prepare metadata
+    - name: Extract tag prefix
+      id: extract_tag
+      # Extract everything between `:` and `@` in the `base-image`
+      run: |
+        TAG_PREFIX=$(echo "${{ matrix.base-image }}" | sed -E 's/[^:]+:([^@]+)@.*/\1/')
+        echo "TAG_PREFIX=$TAG_PREFIX" >> $GITHUB_ENV
+
+    - name: Prepare metadata
       id: meta
       uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a  # v4.0.1
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
-          type=sha,enable=true,prefix=git-
+          type=raw,value=${{ env.TAG_PREFIX }}
           type=raw,value=latest
-          type=raw,value=${{ matrix.base-image | replace('/','-') | replace(':','-') | replace('@','-') }}
 
     - name: Log into registry ${{ env.REGISTRY }}
       uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
 
-    - name: Prepare metadata
+      - name: Prepare metadata
       id: meta
       uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a  # v4.0.1
       with:
@@ -44,6 +44,7 @@ jobs:
         tags: |
           type=sha,enable=true,prefix=git-
           type=raw,value=latest
+          type=raw,value=${{ matrix.base-image | replace('/','-') | replace(':','-') | replace('@','-') }}
 
     - name: Log into registry ${{ env.REGISTRY }}
       uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b  # v2.0.0


### PR DESCRIPTION
IIUC then this might be the solution suggested in https://github.com/mamba-org/micromamba-devcontainer/issues/29#issuecomment-1851100870.

This changes the names to be based on the `BASE_IMAGE`, e.g.,:
- git-8440cec-jammy-{sha256}
- jammy-cuda-11.8.0-{sha256}
