### PR TITLE
Fix autoupdates

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -20,7 +20,7 @@ jobs:
         base-image:
           - mambaorg/micromamba:git-c160e88-jammy@sha256:e3a59f560211ded26e65afafafd20eafc31bad2745db9a2932e39574847a7159
           - mambaorg/micromamba:git-c160e88-jammy-cuda-11.8.0@sha256:804aef13a790647f5145b0e6673f7069c4591e7871d25381ffcd778bf1fe0d4b
-          - mamba-org/micromamba:git-596b6ef-focal-cuda-11.2.2@sha256:74b784b017bfe6c6e8a63d797f79a06a7a4a11c7f79bf11f1fca5e5417ed52cc
+          - mambaorg/micromamba:git-596b6ef-focal-cuda-11.2.2@sha256:74b784b017bfe6c6e8a63d797f79a06a7a4a11c7f79bf11f1fca5e5417ed52cc
     # Set permissions for GitHub token
     # <https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github>
     permissions:

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -17,10 +17,10 @@ jobs:
 
     strategy:
       matrix:
-        base-image:
-          - mambaorg/micromamba:git-c160e88-jammy@sha256:e3a59f560211ded26e65afafafd20eafc31bad2745db9a2932e39574847a7159
-          - mambaorg/micromamba:git-c160e88-jammy-cuda-11.8.0@sha256:804aef13a790647f5145b0e6673f7069c4591e7871d25381ffcd778bf1fe0d4b
-          - mambaorg/micromamba:git-596b6ef-focal-cuda-11.2.2@sha256:74b784b017bfe6c6e8a63d797f79a06a7a4a11c7f79bf11f1fca5e5417ed52cc
+        base-image-name:
+          - jammy
+          - jammy-cuda
+          - focal-cuda
     # Set permissions for GitHub token
     # <https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-on-github>
     permissions:
@@ -37,11 +37,21 @@ jobs:
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6  # v2.0.0
 
+    - name: Extract base image tag from base-images.json
+      id: extract_base_image
+      run: |
+        BASE_IMAGE=$(jq -r ".\"${{ matrix.base-image-name }}\"" docker/base-images.json)
+        echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
+
+    - name: Print the base image
+      run: |
+        echo "Using base image: ${{ env.BASE_IMAGE }}"
+
     - name: Extract tag prefix
       id: extract_tag
       # Extract everything between `:` and `@` in the `base-image`
       run: |
-        TAG_PREFIX=$(echo "${{ matrix.base-image }}" | sed -E 's/[^:]+:([^@]+)@.*/\1/')
+        TAG_PREFIX=$(echo "${{ env.BASE_IMAGE }}" | sed -E 's/[^:]+:([^@]+)@.*/\1/')
         echo "TAG_PREFIX=$TAG_PREFIX" >> $GITHUB_ENV
 
     - name: Prepare metadata
@@ -69,6 +79,6 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        build-args: BASE_IMAGE=${{ matrix.base-image }}
+        build-args: BASE_IMAGE=${{ env.BASE_IMAGE }}
         cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
         cache-to: type=inline

--- a/base-images.json
+++ b/base-images.json
@@ -1,0 +1,5 @@
+{
+    "jammy": "mambaorg/micromamba:git-c160e88-jammy@sha256:e3a59f560211ded26e65afafafd20eafc31bad2745db9a2932e39574847a7159",
+    "jammy-cuda": "mambaorg/micromamba:git-c160e88-jammy-cuda-11.8.0@sha256:804aef13a790647f5145b0e6673f7069c4591e7871d25381ffcd778bf1fe0d4b",
+    "focal-cuda": "mambaorg/micromamba:git-596b6ef-focal-cuda-11.2.2@sha256:74b784b017bfe6c6e8a63d797f79a06a7a4a11c7f79bf11f1fca5e5417ed52cc"
+}


### PR DESCRIPTION
Autoupdates are broken because a workflow isn't allowed to update another workflow. Thus we split out the base images into a separate JSON file.